### PR TITLE
Add csimdv to count benchmark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,6 +116,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "csimdv"
+version = "0.1.0"
+source = "git+https://github.com/juliusgeo/csimdv-rs.git#84f8dc7f5469d304dbd5d80d16d76d46bb61cdc3"
+
+[[package]]
 name = "csv"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -247,6 +252,7 @@ dependencies = [
  "anyhow",
  "bstr",
  "clap",
+ "csimdv",
  "csv",
  "memchr",
  "memmap2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,3 +37,4 @@ bstr = "1.12.0"
 clap = { version = "4.5.47", features = ["derive"] }
 csv = "1.3.1"
 memmap2 = "0.9.8"
+csimdv = { git = "https://github.com/juliusgeo/csimdv-rs.git" }

--- a/examples/count.rs
+++ b/examples/count.rs
@@ -182,10 +182,7 @@ fn main() -> anyhow::Result<()> {
             let file = File::open(&args.path)?;
             let mut p = Parser::new(default_dialect(), AlignedBuffer::new(file));
             let mut count = 0;
-            while let Some(mut record) = p.read_line() {
-                for field in record.iter() {
-                    let _ = field.len();
-                }
+            while let Some(_) = p.read_line() {
                 count += 1;
             }
             println!("{}", count);

--- a/examples/count.rs
+++ b/examples/count.rs
@@ -13,6 +13,7 @@ enum CountingMode {
     Copy,
     MmapCopy,
     Lines,
+    CSimdV
 }
 
 #[derive(Parser, Debug)]
@@ -174,6 +175,20 @@ fn main() -> anyhow::Result<()> {
             let mut reader = simd_csv::LineReader::from_reader(file);
 
             println!("{}", reader.count_lines()?);
+        }
+        CountingMode::CSimdV => {
+            use csimdv::{default_dialect, Parser};
+            use csimdv::aligned_buffer::AlignedBuffer;
+            let file = File::open(&args.path)?;
+            let mut p = Parser::new(default_dialect(), AlignedBuffer::new(file));
+            let mut count = 0;
+            while let Some(mut record) = p.read_line() {
+                for field in record.iter() {
+                    let _ = field.len();
+                }
+                count += 1;
+            }
+            println!("{}", count);
         }
     }
 

--- a/scripts/bench.sh
+++ b/scripts/bench.sh
@@ -30,7 +30,8 @@ do
     "$PROG baseline $path" \
     "$PROG simd $path" \
     "$PROG zero-copy $path" \
-    "$PROG copy $path"
+    "$PROG copy $path" \
+    "$PROG c-simd-v $path"
 
   printf %"$(tput cols)"s | tr " " "-"
   echo


### PR DESCRIPTION
Adds csimdv to benchmark file.
On my aarch64 machine, it works without any rustflags. On x86_64 (Windows), I had to provide `RUSTFLAGS="target-cpu=native"`.